### PR TITLE
Fixed some basic formatting annoyances, merging from dev into master

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,12 @@ A default output target can also be specified using `"default_target"` *(optiona
 ## Planned features
 - [ ] Compiler-specific flags per target
 - [ ] Platform-specific imports!!
+- [ ] Generate comments in the CMakeLists.txt file
 
 ## Finished planned features
 - [x] Specification of individual, non-recursive include directories
+
+## Misc. TODOS
+- [ ] Refactor data into classes
+- [ ] Improve error handling, and do it right
+- [ ] Add a script to create precompiled headers

--- a/file_write.py
+++ b/file_write.py
@@ -24,26 +24,26 @@ class CMakeBuilder():
             defaultCppStandard = allowedCppStandards[0]
 
         self.printToOwnStream("\nset( CXX_COMPILER_STANDARD \"", defaultCppStandard, "\" CACHE STRING \"C++ compiler standard year\")", sep="")
-        self.printToOwnStream("\nset_property( CACHE CXX_COMPILER_STANDARD PROPERTY STRINGS", end="")
+        self.printToOwnStream("set_property( CACHE CXX_COMPILER_STANDARD PROPERTY STRINGS ", end="")
 
         for standard in allowedCppStandards:
-            self.printToOwnStream(" \"", standard, "\"", sep="", end="")
+            self.printToOwnStream("\"", standard, "\" ", sep="", end="")
         self.printToOwnStream(")")
 
-        self.writeMessage("Using CXX compiler standard -std=c++${CXX_COMPILER_STANDARD}", before="\n")
+        self.writeMessage("Using CXX compiler standard -std=c++${CXX_COMPILER_STANDARD}")
 
     def writeCStandards(self, allowedCStandards, defaultCStandard = ""):
         if not defaultCStandard in allowedCStandards or defaultCStandard == "":
             defaultCStandard = allowedCStandards[0]
 
         self.printToOwnStream("\nset( C_COMPILER_STANDARD \"", defaultCStandard, "\" CACHE STRING \"C compiler standard year\")", sep="")
-        self.printToOwnStream("\nset_property( CACHE C_COMPILER_STANDARD PROPERTY STRINGS", end="")
+        self.printToOwnStream("set_property( CACHE C_COMPILER_STANDARD PROPERTY STRINGS ", end="")
 
         for standard in allowedCStandards:
-            self.printToOwnStream(" \"", standard, "\"", sep="", end="")
+            self.printToOwnStream("\"", standard, "\" ", sep="", end="")
         self.printToOwnStream(")")
 
-        self.writeMessage("Using C compiler standard -std=c${C_COMPILER_STANDARD}", before="\n")
+        self.writeMessage("Using C compiler standard -std=c${C_COMPILER_STANDARD}")
 
     def writeExecutableOutput(self, name, sourcesArr, includeDirsArr, exeOutputDir):
         outputTargetWriteName = HelperFunctions.getOutputCmakeName(name)
@@ -189,7 +189,8 @@ class CMakeBuilder():
         for flag in cFlags:
             self.printToOwnStream(flag, end=" ")
         self.printToOwnStream("\" CACHE STRING \"C Compiler options\" )")
-        self.writeMessage("Using C compiler flags: ${C_FLAGS}")
+        self.writeMessage("Using C compiler flags: ${C_FLAGS}", before="\t")
+        self.writeNewlines(1)
 
         # CXX flag section
         self.printToOwnStream("\tset( CXX_FLAGS \"", end="")
@@ -197,7 +198,8 @@ class CMakeBuilder():
         for flag in cppFlags:
             self.printToOwnStream(flag, end=" ")
         self.printToOwnStream("\" CACHE STRING \"CXX Compiler options\" )")
-        self.writeMessage("Using CXX compiler flags: ${CXX_FLAGS}")
+        self.writeMessage("Using CXX compiler flags: ${CXX_FLAGS}", before="\t")
+        self.writeNewlines(1)
 
         self.writeMessage("Building project ${CMAKE_BUILD_TYPE} configuration", before="\t")
         self.writeEndif()


### PR DESCRIPTION
Fixed indentation annoyances in CMakeLists.txt. This wasn't a functionality issue, but was annoying when trying to read through the file. Everything is now formatted as intended.